### PR TITLE
Add support for CGD's Hobart cluster

### DIFF
--- a/ncar_jobqueue/cluster.py
+++ b/ncar_jobqueue/cluster.py
@@ -46,9 +46,9 @@ class NCARCluster(_base_class):
     -------
     cluster : object
 
-         - PBSCluster, if the host on Cheyenne cluster or Hobart cluster
-         - SLURMCluster, if the host is on Casper cluster
-         - Throws exception, if the host is neither on Cheyenne, Hobart nor Casper clusters
+         - PBSCluster, if the host on Cheyenne cluster or Hobart cluster.
+         - SLURMCluster, if the host is on Casper cluster.
+         - Throws exception otherwise.
     """
 
     def __init__(self, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=dask,dask_jobqueue,pkg_resources,setuptools
+known_third_party=dask_jobqueue,pkg_resources,setuptools
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
- Addresses #9 
- Uses `socket.getfqdn()`, which returns a fully qualified domain name if it's available or `gethostname()` otherwise as suggested in #7 
