### PR TITLE
Bug Fix: Replace resource_stream() with resource_filename()

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: "*"
+  pull_request:
+    branches: master
 
 
 jobs:

--- a/ncar_jobqueue/config.py
+++ b/ncar_jobqueue/config.py
@@ -95,11 +95,11 @@ def _generate_config(config_data_file_path, template_file_path):
     return data
 
 
-config_data_file_path = pkg_resources.resource_stream(
+config_data_file_path = pkg_resources.resource_filename(
     "ncar_jobqueue", "host_configs.yaml"
 )
 
-template_file_path = pkg_resources.resource_stream(
+template_file_path = pkg_resources.resource_filename(
     "ncar_jobqueue", "jobqueue_template.yaml"
 )
 


### PR DESCRIPTION
- Replace `resource_stream()` with `resource_filename()`. `resource_stream()` produced the following bug:

```python
In [1]: import ncar_jobqueue                                                                                   
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-038736755653> in <module>
----> 1 import ncar_jobqueue

/glade/work/abanihi/softwares/miniconda3/envs/analysis/lib/python3.7/site-packages/ncar_jobqueue/__init__.py in <module>
      3 from pkg_resources import DistributionNotFound, get_distribution
      4 
----> 5 from . import config
      6 from .cluster import NCARCluster
      7 

/glade/work/abanihi/softwares/miniconda3/envs/analysis/lib/python3.7/site-packages/ncar_jobqueue/config.py in <module>
    109 destination = os.path.join(os.path.expanduser("~"), ".dask")
    110 with open(config_path, "w") as outfile:
--> 111     data = _generate_config(config_data_file_path, template_file_path)
    112     data = yaml.safe_load(data)
    113     yaml.dump(data, outfile, default_flow_style=False)

/glade/work/abanihi/softwares/miniconda3/envs/analysis/lib/python3.7/site-packages/ncar_jobqueue/config.py in _generate_config(config_data_file_path, template_file_path)
     78 
     79     # Load data from YAML into Python dictionary
---> 80     config_data = yaml.safe_load(open(config_data_file_path))
     81     config_data["host"] = host
     82 

TypeError: expected str, bytes or os.PathLike object, not _io.BufferedReader
```