### PR TITLE
Remove Cheyenne doc and fix Casper paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
   - [Installation](#installation)
   - [Configuration](#configuration)
   - [Usage](#usage)
-    - [Derecho](#derecho)
     - [Casper](#casper)
+    - [Derecho](#derecho)
     - [Hobart](#hobart)
     - [Izumi](#izumi)
     - [Non-NCAR machines](#non-ncar-machines)
@@ -20,10 +20,12 @@
 
 The following compute servers are supported:
 
+- Casper (casper.hpc.ucar.edu)
 - Derecho (derecho.hpc.ucar.edu)
-- Casper (DAV) (casper.ucar.edu)
 - Hobart (hobart.cgd.ucar.edu)
 - Izumi (izumi.unified.ucar.edu)
+
+**CISL discourages the use of Derecho for Dask. Please use Casper instead unless you are sure you can properly utilize a significant portion of the CPU cores on a Derecho node (e.g., via [dask-mpi](https://mpi.dask.org/en/latest/)).**
 
 ## Installation
 
@@ -47,37 +49,37 @@ conda install -c conda-forge ncar-jobqueue
 <summary>ncar-jobqueue.yaml</summary>
 
 ```yaml
+casper:
+  pbs:
+    #project: XXXXXXXX
+    name: dask-worker-casper
+    cores: 1 # Total number of cores per job
+    memory: '4GiB' # Total amount of memory per job
+    processes: 1 # Number of Python processes per job
+    interface: ext # Network interface to use (high-speed ethernet)
+    walltime: '01:00:00'
+    resource-spec: select=1:ncpus=1:mem=4GB
+    queue: casper
+    log-directory: '/glade/derecho/scratch/${USER}/dask/casper/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/casper/local-dir'
+    job-extra: ['-r n']
+    env-extra: []
+    death-timeout: 60
+
 derecho:
   pbs:
     #project: XXXXXXXX
     name: dask-worker-derecho
-    cores: 128 # Total number of cores per job
-    memory: '235GB' # Total amount of memory per job
-    processes: 32 # Number of Python processes per job
-    interface: hsn0 # Network interface to use like eth0 or ib0
-    queue: main
+    cores: 1 # Total number of cores per job
+    memory: '4GiB' # Total amount of memory per job
+    processes: 1 # Number of Python processes per job
+    interface: hsn0 # Network interface to use (Slingshot)
+    queue: develop
     walltime: '01:00:00'
     resource-spec: select=1:ncpus=128:mem=235GB
-    log-directory: '/glade/derecho/scratch/${USER}/dask/logs'
-    local-directory: '/glade/derecho/scratch/${USER}/dask/local-dir'
-    job-extra: ['-l job_priority=economy']
-    env-extra: []
-    death-timeout: 60
-
-casper-dav:
-  pbs:
-    #project: XXXXXXXX
-    name: dask-worker-casper-dav
-    cores: 2 # Total number of cores per job
-    memory: '25GB' # Total amount of memory per job
-    processes: 1 # Number of Python processes per job
-    interface: ib0
-    walltime: '01:00:00'
-    resource-spec: select=1:ncpus=1:mem=25GB
-    queue: casper
-    log-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/logs'
-    local-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/local-dir'
-    job-extra: []
+    log-directory: '/glade/derecho/scratch/${USER}/dask/derecho/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/derecho/local-dir'
+    job-extra: ['-l job_priority=economy', '-r -n']
     env-extra: []
     death-timeout: 60
 
@@ -126,7 +128,7 @@ izumi:
 
 ⚠️ Online documentation for `dask-jobqueue` is available [here][rtd-link]. ⚠️
 
-### Derecho
+### Casper
 
 ```python
 >>> from ncar_jobqueue import NCARCluster
@@ -138,7 +140,7 @@ PBSCluster(0f23b4bf, 'tcp://xx.xxx.x.x:xxxx', workers=0, threads=0, memory=0 B)
 >>> client = Client(cluster)
 ```
 
-### Casper
+### Derecho
 
 ```python
 >>> from ncar_jobqueue import NCARCluster

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   - [Usage](#usage)
     - [Derecho](#derecho)
     - [Casper](#casper)
-    - [Cheyenne](#cheyenne)
     - [Hobart](#hobart)
     - [Izumi](#izumi)
     - [Non-NCAR machines](#non-ncar-machines)
@@ -22,7 +21,6 @@
 The following compute servers are supported:
 
 - Derecho (derecho.hpc.ucar.edu)
-- Cheyenne (cheyenne.ucar.edu)
 - Casper (DAV) (casper.ucar.edu)
 - Hobart (hobart.cgd.ucar.edu)
 - Izumi (izumi.unified.ucar.edu)
@@ -49,20 +47,20 @@ conda install -c conda-forge ncar-jobqueue
 <summary>ncar-jobqueue.yaml</summary>
 
 ```yaml
-cheyenne:
+derecho:
   pbs:
     #project: XXXXXXXX
-    name: dask-worker-cheyenne
-    cores: 18 # Total number of cores per job
-    memory: '109GB' # Total amount of memory per job
-    processes: 18 # Number of Python processes per job
-    interface: ib0 # Network interface to use like eth0 or ib0
-    queue: regular
+    name: dask-worker-derecho
+    cores: 128 # Total number of cores per job
+    memory: '235GB' # Total amount of memory per job
+    processes: 32 # Number of Python processes per job
+    interface: hsn0 # Network interface to use like eth0 or ib0
+    queue: main
     walltime: '01:00:00'
-    resource-spec: select=1:ncpus=36:mem=109GB
-    log-directory: '/glade/scratch/${USER}/dask/cheyenne/logs'
-    local-directory: '/glade/scratch/${USER}/dask/cheyenne/local-dir'
-    job-extra: []
+    resource-spec: select=1:ncpus=128:mem=235GB
+    log-directory: '/glade/derecho/scratch/${USER}/dask/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/local-dir'
+    job-extra: ['-l job_priority=economy']
     env-extra: []
     death-timeout: 60
 
@@ -77,8 +75,8 @@ casper-dav:
     walltime: '01:00:00'
     resource-spec: select=1:ncpus=1:mem=25GB
     queue: casper
-    log-directory: '/glade/scratch/${USER}/dask/casper-dav/logs'
-    local-directory: '/glade/scratch/${USER}/dask/casper-dav/local-dir'
+    log-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/local-dir'
     job-extra: []
     env-extra: []
     death-timeout: 60
@@ -141,18 +139,6 @@ PBSCluster(0f23b4bf, 'tcp://xx.xxx.x.x:xxxx', workers=0, threads=0, memory=0 B)
 ```
 
 ### Casper
-
-```python
->>> from ncar_jobqueue import NCARCluster
->>> from dask.distributed import Client
->>> cluster = NCARCluster(project='XXXXXXXX')
->>> cluster
-PBSCluster(0f23b4bf, 'tcp://xx.xxx.x.x:xxxx', workers=0, threads=0, memory=0 B)
->>> cluster.scale(jobs=2)
->>> client = Client(cluster)
-```
-
-### Cheyenne
 
 ```python
 >>> from ncar_jobqueue import NCARCluster

--- a/ncar_jobqueue/ncar-jobqueue.yaml
+++ b/ncar_jobqueue/ncar-jobqueue.yaml
@@ -43,8 +43,8 @@ casper-dav:
     walltime: '01:00:00'
     resource-spec: select=1:ncpus=1:mem=25GB
     queue: casper
-    log-directory: '/glade/scratch/${USER}/dask/casper-dav/logs'
-    local-directory: '/glade/scratch/${USER}/dask/casper-dav/local-dir'
+    log-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/local-dir'
     job-extra: []
     env-extra: []
     death-timeout: 60

--- a/ncar_jobqueue/ncar-jobqueue.yaml
+++ b/ncar_jobqueue/ncar-jobqueue.yaml
@@ -2,16 +2,16 @@ derecho:
   pbs:
     #    project: XXXXXXXX
     name: dask-worker-derecho
-    cores: 128 # Total number of cores per job
-    memory: '235GB' # Total amount of memory per job
-    processes: 32 # Number of Python processes per job
-    interface: hsn0 # Network interface to use like eth0 or ib0
-    queue: main
+    cores: 1 # Total number of cores per job
+    memory: '4GiB' # Total amount of memory per job
+    processes: 1 # Number of Python processes per job
+    interface: hsn0 # Network interface to use (Slingshot)
+    queue: develop
     walltime: '01:00:00'
-    resource-spec: select=1:ncpus=128:mem=235GB
-    log-directory: '/glade/derecho/scratch/${USER}/dask/logs'
-    local-directory: '/glade/derecho/scratch/${USER}/dask/local-dir'
-    job-extra: ['-l job_priority=economy']
+    resource-spec: select=1:ncpus=1:mem=4GB
+    log-directory: '/glade/derecho/scratch/${USER}/dask/derecho/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/derecho/local-dir'
+    job-extra: ['-l job_priority=economy', '-r n']
     env-extra: []
     death-timeout: 60
 
@@ -20,7 +20,7 @@ cheyenne:
     #    project: XXXXXXXX
     name: dask-worker-cheyenne
     cores: 36 # Total number of cores per job
-    memory: '109GB' # Total amount of memory per job
+    memory: '109GiB' # Total amount of memory per job
     processes: 9 # Number of Python processes per job
     interface: ext # Network interface to use like eth0 or ib0
     queue: regular
@@ -32,20 +32,20 @@ cheyenne:
     env-extra: []
     death-timeout: 60
 
-casper-dav:
+casper:
   pbs:
     #    project: XXXXXXXX
-    name: dask-worker-casper-dav
-    cores: 2 # Total number of cores per job
-    memory: '25GB' # Total amount of memory per job
+    name: dask-worker-casper
+    cores: 1 # Total number of cores per job
+    memory: '4GiB' # Total amount of memory per job
     processes: 1 # Number of Python processes per job
-    interface: ext
+    interface: ext # Network interface to use (high-speed ethernet)
     walltime: '01:00:00'
-    resource-spec: select=1:ncpus=1:mem=25GB
+    resource-spec: select=1:ncpus=1:mem=4GB
     queue: casper
-    log-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/logs'
-    local-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/local-dir'
-    job-extra: []
+    log-directory: '/glade/derecho/scratch/${USER}/dask/casper/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/casper/local-dir'
+    job-extra: ['-r n']
     env-extra: []
     death-timeout: 60
 


### PR DESCRIPTION
The primary purpose of this PR is to fix the log and local paths for the Casper cluster definition, as the current setup points to Cheyenne scratch spaces which no longer exist. I've also proposed removing the documentation of Cheyenne, since it can no longer be used. I left the Cheyenne definition in the yaml file as a historical reference, but that could be removed as well if preferred.