### PR TITLE
Casper resource updates and some recommendations for Derecho 

### DIFF
--- a/ncar_jobqueue/ncar-jobqueue.yaml
+++ b/ncar_jobqueue/ncar-jobqueue.yaml
@@ -2,16 +2,16 @@ derecho:
   pbs:
     #    project: XXXXXXXX
     name: dask-worker-derecho
-    cores: 128 # Total number of cores per job
-    memory: '235GB' # Total amount of memory per job
-    processes: 32 # Number of Python processes per job
+    cores: 1 # Total number of cores per job
+    memory: '4GB' # Total amount of memory per job
+    processes: 1 # Number of Python processes per job
     interface: hsn0 # Network interface to use like eth0 or ib0
     queue: main
     walltime: '01:00:00'
     resource-spec: select=1:ncpus=128:mem=235GB
     log-directory: '/glade/derecho/scratch/${USER}/dask/logs'
     local-directory: '/glade/derecho/scratch/${USER}/dask/local-dir'
-    job-extra: ['-l job_priority=economy']
+    job-extra: ['-l job_priority=economy','-r n']
     env-extra: []
     death-timeout: 60
 
@@ -36,16 +36,16 @@ casper-dav:
   pbs:
     #    project: XXXXXXXX
     name: dask-worker-casper-dav
-    cores: 2 # Total number of cores per job
-    memory: '25GB' # Total amount of memory per job
+    cores: 1 # Total number of cores per job
+    memory: '4GB' # Total amount of memory per job
     processes: 1 # Number of Python processes per job
     interface: ext
     walltime: '01:00:00'
     resource-spec: select=1:ncpus=1:mem=25GB
     queue: casper
-    log-directory: '/glade/scratch/${USER}/dask/casper-dav/logs'
-    local-directory: '/glade/scratch/${USER}/dask/casper-dav/local-dir'
-    job-extra: []
+    log-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/logs'
+    local-directory: '/glade/derecho/scratch/${USER}/dask/casper-dav/local-dir'
+    job-extra: ['-r n']
     env-extra: []
     death-timeout: 60
 

--- a/ncar_jobqueue/ncar-jobqueue.yaml
+++ b/ncar_jobqueue/ncar-jobqueue.yaml
@@ -11,7 +11,7 @@ derecho:
     resource-spec: select=1:ncpus=128:mem=235GB
     log-directory: '/glade/derecho/scratch/${USER}/dask/logs'
     local-directory: '/glade/derecho/scratch/${USER}/dask/local-dir'
-    job-extra: ['-l job_priority=economy','-r n']
+    job-extra: ['-q develop@desched1','-r n']
     env-extra: []
     death-timeout: 60
 


### PR DESCRIPTION
Here are some better resource selection for ncar cluster that will fix some issues, especially on Casper. 

First 4GB workers is more appropriate on Casper. I have added some other Casper-relevant and PBS relevant options for Casper so the jobs will not be held in the queue. 

For Derecho: Running dak workflows on Derecho should be avoided but Derecho now has a shared queue that can be possibly more useful for some development workflows. 
