### PR TITLE
Replace pkg_resources usage

### DIFF
--- a/ncar_jobqueue/__init__.py
+++ b/ncar_jobqueue/__init__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 # flake8: noqa
 """ Top-level module for ncar-jobqueue. """
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 from . import config
 from .cluster import NCARCluster
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version('ncar-jobqueue')
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     _version__ = '0.0.0'  # pragma: no cover

--- a/ncar_jobqueue/config.py
+++ b/ncar_jobqueue/config.py
@@ -3,9 +3,9 @@ import datetime
 import os
 import pathlib
 import shutil
+from importlib.resources import as_file, files
 
 import dask
-import pkg_resources
 import yaml
 
 from .util import identify_host
@@ -39,11 +39,10 @@ def configure(destination_path):
     )
 
 
-config_data_file_path = pathlib.Path(
-    pkg_resources.resource_filename('ncar_jobqueue', 'ncar-jobqueue.yaml')
-)
+config_data_file = files('ncar_jobqueue').joinpath('ncar-jobqueue.yaml')
 destination_dir = pathlib.Path(dask.config.PATH)
-destination_path = destination_dir / config_data_file_path.parts[-1]
+destination_path = destination_dir / config_data_file.name
 
-ensure_file(source=config_data_file_path, destination_path=destination_path)
+with as_file(config_data_file) as config_data_file_path:
+    ensure_file(source=config_data_file_path, destination_path=destination_path)
 configure(destination_path)


### PR DESCRIPTION
## Summary

- replace the import-time version lookup with `importlib.metadata.version(ncar-jobqueue)`
- replace `pkg_resources.resource_filename()` with `importlib.resources.files()` / `as_file()` for the packaged YAML config
- remove direct `pkg_resources` imports from the package

Fixes #122.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|get_distribution|DistributionNotFound|resource_filename .`
- Not run locally