### PR TITLE
Use NCAR_HOST for host detection

### DIFF
--- a/ncar_jobqueue/util.py
+++ b/ncar_jobqueue/util.py
@@ -1,3 +1,4 @@
+import os
 import re
 import socket
 from collections import namedtuple
@@ -37,9 +38,22 @@ regexes = [
     ('derecho', derecho_login),
 ]
 
+NCAR_HOSTS = {
+    'casper': 'casper-dav',
+    'cheyenne': 'cheyenne',
+    'dav': 'casper-dav',
+    'derecho': 'derecho',
+    'hobart': 'hobart',
+    'izumi': 'izumi',
+}
+
 
 def identify_host():
     """Function to determine which host the client is running from."""
+
+    ncar_host = os.environ.get('NCAR_HOST', '').lower()
+    if ncar_host in NCAR_HOSTS:
+        return NCAR_HOSTS[ncar_host]
 
     hostname = socket.getfqdn()
     return next((name for name, regex in regexes if regex.search(hostname)), 'unknown')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,15 @@
 from ncar_jobqueue.util import identify_host, in_notebook, is_running_from_jupyterhub
 
 
-def test_identify_host():
+def test_identify_host(monkeypatch):
+    monkeypatch.delenv('NCAR_HOST', raising=False)
     assert 'unknown' == identify_host()
+
+
+def test_identify_host_from_ncar_host(monkeypatch):
+    monkeypatch.setenv('NCAR_HOST', 'dav')
+
+    assert 'casper-dav' == identify_host()
 
 
 def test_in_notebook():


### PR DESCRIPTION
## Summary

- Prefer the `NCAR_HOST` environment variable when identifying the current NCAR host.
- Map `NCAR_HOST=dav` and `NCAR_HOST=casper` to the existing `casper-dav` cluster key.
- Keep the existing FQDN regex matching as the fallback when `NCAR_HOST` is unset or unrecognized.
- Add a regression for `NCAR_HOST=dav`.

## Validation

- `git diff --check HEAD~1..HEAD`
- Static search for the new `NCAR_HOST` mapping and regression test
- Tests not run locally.

Fixes #58