### PR TITLE
Move from pkg_resources to importlib.metadata

### DIFF
--- a/ncar_jobqueue/__init__.py
+++ b/ncar_jobqueue/__init__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 # flake8: noqa
 """ Top-level module for ncar-jobqueue. """
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 from . import config
 from .cluster import NCARCluster
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version(__name__)
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     _version__ = '0.0.0'  # pragma: no cover

--- a/ncar_jobqueue/config.py
+++ b/ncar_jobqueue/config.py
@@ -5,7 +5,7 @@ import pathlib
 import shutil
 
 import dask
-import pkg_resources
+from importlib.resources import files
 import yaml
 
 from .util import identify_host
@@ -39,9 +39,7 @@ def configure(destination_path):
     )
 
 
-config_data_file_path = pathlib.Path(
-    pkg_resources.resource_filename('ncar_jobqueue', 'ncar-jobqueue.yaml')
-)
+config_data_file_path = files('ncar_jobqueue') / 'ncar-jobqueue.yaml'
 destination_dir = pathlib.Path(dask.config.PATH)
 destination_path = destination_dir / config_data_file_path.parts[-1]
 

--- a/ncar_jobqueue/config.py
+++ b/ncar_jobqueue/config.py
@@ -3,9 +3,9 @@ import datetime
 import os
 import pathlib
 import shutil
+from importlib.resources import files
 
 import dask
-from importlib.resources import files
 import yaml
 
 from .util import identify_host


### PR DESCRIPTION
`pkg_resources` was moved from `setuptools` in v82.0.0. The recommendation is to use `importlib.metadata` instead.

Fixes #122 

Testing:

Using 4947c0c with python 3.13.12

```python
>>> import ncar_jobqueue
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import ncar_jobqueue
  File "/glade/work/mlevy/codes/CUPiD/externals/ncar-jobqueue/ncar_jobqueue/__init__.py", line 4, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
>>>
```

This branch

```python
>>> import ncar_jobqueue
>>>
```

note this is on Casper; on derecho we get a new error:

```python
>>> import ncar_jobqueue
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import ncar_jobqueue
  File "/glade/work/mlevy/codes/CUPiD/externals/ncar-jobqueue/ncar_jobqueue/__init__.py", line 6, in <module>
    from . import config
  File "/glade/work/mlevy/codes/CUPiD/externals/ncar-jobqueue/ncar_jobqueue/config.py", line 47, in <module>
    configure(destination_path)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/glade/work/mlevy/codes/CUPiD/externals/ncar-jobqueue/ncar_jobqueue/config.py", line 30, in configure
    original_data = yaml.safe_load(f)[host]
                    ~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'derecho'
>>>
```

Really we just need NCAR users to switch to `PBSCluster` objects, this project hasn't been necessary since casper switched from SLURM to PBS to match cheyenne...